### PR TITLE
feat: Create English translation file for drc_mini_dossier_form

### DIFF
--- a/distro/configuration/ampathformstranslations/drc_mini_dossier_form_translations_en-core_demo.json
+++ b/distro/configuration/ampathformstranslations/drc_mini_dossier_form_translations_en-core_demo.json
@@ -1,0 +1,29 @@
+{
+  "uuid": "8909ebad-9245-4624-aaaa-0e6289c0240e",
+  "form": "DRC Mini Dossier",
+  "description": "English Translations for 'DRC Mini Dossier' form as a demo example for PATH DRC on how to translate forms",
+  "language": "en",
+  "translations": {
+    "Psychosocial Care": "Psychosocial Care",
+    "Interventions": "Interventions",
+    "Need an intervention": "Need an intervention",
+    "Yes": "Yes",
+    "No": "No",
+    "Type of psychological  intervention": "Type of psychological  intervention",
+    "Family support": "Family support",
+    "Home visit requested by health facility": "Home visit requested by health facility",
+    "Legal services": "Legal services",
+    "Nutritional support": "Nutritional support",
+    "Other": "Other",
+    "Patient education": "Patient education",
+    "Psychosocial counseling": "Psychosocial counseling",
+    "Prophylaxis IO": "Prophylaxis IO",
+    "Medicines": "Medicines",
+    "Cotrimoxazole start date": "Cotrimoxazole start date",
+    "Cotrimoxazole stop date": "Cotrimoxazole stop date",
+    "Reason for stopping Cotrimoxazole": "Reason for stopping Cotrimoxazole",
+    "Fluconazole start date": "Fluconazole start date",
+    "Fluconazole stop date": "Fluconazole stop date",
+    "Reason for stopping Fluconazole": "Reason for stopping Fluconazole"
+  }
+}


### PR DESCRIPTION
We learned today that you ALSO need an English translation file (even though this feels duplicative), otherwise ONLY French shows up in the Form, even when you switch your language preference to English!